### PR TITLE
Deploy the wasm build to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,18 @@ jobs:
       - run: ./gradlew iosSimulatorArm64Test --stacktrace
       - run: ./gradlew :app:desktopApp:assemble --stacktrace
 
+  web:
+    name: Web (wasm) distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :app:webApp:wasmJsBrowserDistribution --stacktrace
+
   navgraph:
     name: Navigation graph check
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,59 @@
+name: Deploy Web
+
+# Publishes the Kotlin/Wasm build to GitHub Pages, so the app can be tried in a browser without
+# installing anything. Pages allows a single deployment per repository, which is why this workflow
+# owns it and the preview gallery publishes a downloadable artifact instead.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deployments race for the one Pages site. In-progress runs finish rather than being
+# cancelled, so a deploy is never interrupted half way.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build wasm distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew :app:webApp:wasmJsBrowserDistribution --stacktrace
+
+      # Pages runs Jekyll over the upload unless told not to, which would drop the files webpack
+      # names with a leading underscore.
+      - name: Disable Jekyll processing
+        run: touch app/webApp/build/dist/wasmJs/productionExecutable/.nojekyll
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: app/webApp/build/dist/wasmJs/productionExecutable
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/preview-gallery.yml
+++ b/.github/workflows/preview-gallery.yml
@@ -1,7 +1,8 @@
 name: Preview Gallery
 
-# Captures every @Preview on a real emulator with Compose HotSwan and publishes the generated
-# catalog to GitHub Pages.
+# Captures every @Preview on a real emulator with Compose HotSwan and uploads the generated
+# catalog as a build artifact. GitHub Pages allows one deployment per repository and the web app
+# owns it, so the gallery is downloaded from the run rather than hosted.
 #
 # HotSwan renders previews inside the running app process rather than in a headless renderer, so
 # the captures include everything a device does: Compose Multiplatform string resources, the real
@@ -17,8 +18,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: preview-gallery
@@ -83,20 +82,3 @@ jobs:
           path: .hotswan/preview-captures/
           retention-days: 30
 
-      # The task writes an index.html beside the PNGs, so the artifact is already a whole site.
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: .hotswan/preview-captures/
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: capture
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/configure-pages@v5
-      - id: deployment
-        uses: actions/deploy-pages@v4

--- a/app/shared/src/wasmJsMain/kotlin/com/skydoves/nowinandroid/ui/image/NiaLandscapist.wasmJs.kt
+++ b/app/shared/src/wasmJsMain/kotlin/com/skydoves/nowinandroid/ui/image/NiaLandscapist.wasmJs.kt
@@ -44,12 +44,24 @@ internal actual fun imageHttpClient(httpClient: HttpClient): HttpClient = httpCl
                 val url = request.url
                 if (url.host == FIREBASE_STORAGE_HOST) {
                     localIconNameOf(url.encodedPathSegments)?.let { name ->
-                        request.url.takeFrom("${window.location.origin}/$LOCAL_TOPIC_ICONS/$name")
+                        request.url.takeFrom("${baseUrl()}/$LOCAL_TOPIC_ICONS/$name")
                     }
                 }
             }
         },
     )
+}
+
+/**
+ * The directory this page is served from.
+ *
+ * Not `window.location.origin`: on GitHub Pages the app lives under a repository subpath, and an
+ * origin-rooted URL would miss it. Taking the path up to the last `/` works both there and at the
+ * root of a dev server.
+ */
+private fun baseUrl(): String {
+    val directory = window.location.pathname.substringBeforeLast('/', missingDelimiterValue = "")
+    return "${window.location.origin}$directory"
 }
 
 /**


### PR DESCRIPTION
The browser build is the one target anyone can try without installing anything, so it is worth hosting. This publishes it on every push to `main`, and adds a wasm job to the PR build, which had no wasm coverage at all.

Once merged the app will be at **https://skydoves.github.io/nowinandroid-kmp/**.

## A bug this surfaced

The topic-icon rewrite built URLs from `window.location.origin`, which drops the repository subpath. On Pages that resolves to `skydoves.github.io/topics/…` rather than `skydoves.github.io/nowinandroid-kmp/topics/…`, so **every topic icon would have 404'd**. It never showed locally because the dev server serves from the root.

The base now comes from `location.pathname`, and I verified it by serving the real production distribution from a `/nowinandroid-kmp/` subpath in headless Chrome: the feed renders, icons load, no 404s.

## Pages can only have one deployer

`preview-gallery.yml` was already deploying to Pages. GitHub allows a single deployment per repository, so with two workflows publishing, whichever finished last would silently overwrite the other.

The web app now owns Pages. The gallery keeps the 30-day downloadable artifact it already uploaded, losing only the hosting, and its now-unnecessary `pages: write` / `id-token: write` permissions are dropped.

## Details worth a look

- **`.nojekyll`** on the upload. Without it Pages runs Jekyll over the output and silently drops webpack's underscore-prefixed files.
- **`concurrency: group: pages, cancel-in-progress: false`** so deploys queue instead of cancelling; a half-written publish is worse than a slow one.
- The deploy also runs on `workflow_dispatch`, so the site can be republished without an empty commit.

## Before this works

Pages has to be switched to the Actions source once: **Settings → Pages → Source → GitHub Actions**. Until then the deploy job fails on permissions.

Note there is no `gh-pages` branch involved — `actions/deploy-pages` uploads an artifact and deploys it directly, which is why the branch-based source setting is the wrong one here.

## Verification

Every Gradle task the three workflows invoke resolves (11 of them), all three files parse as valid YAML, and the upload path exists after a real `wasmJsBrowserDistribution`.

| | |
|---|---|
| `desktopTest` | 158 tests, 0 failures |
| `testAndroidHostTest` | 117 tests, 0 failures |
| `iosSimulatorArm64Test` | 139 tests, 0 failures |
| `spotlessCheck` · `navCheck` · Android APK · wasm distribution | green |
