### PR TITLE
Let the deploy workflow enable Pages itself

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -3,6 +3,9 @@ name: Deploy Web
 # Publishes the Kotlin/Wasm build to GitHub Pages, so the app can be tried in a browser without
 # installing anything. Pages allows a single deployment per repository, which is why this workflow
 # owns it and the preview gallery publishes a downloadable artifact instead.
+#
+# There is no gh-pages branch: `deploy-pages` uploads an artifact and serves it directly, and the
+# first run switches the repository's Pages source to GitHub Actions itself.
 
 on:
   push:
@@ -41,7 +44,11 @@ jobs:
       - name: Disable Jekyll processing
         run: touch app/webApp/build/dist/wasmJs/productionExecutable/.nojekyll
 
+      # `enablement` turns Pages on the first time this runs, so the site does not depend on
+      # someone having flipped the source to GitHub Actions in the repository settings by hand.
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The first `Deploy Web` run on `main` failed:

```
Get Pages site failed. Please verify that the repository has Pages enabled and
configured to build using GitHub Actions, or consider exploring the `enablement`
parameter for this action.
```

The wasm build itself was fine — `BUILD SUCCESSFUL in 3m 58s`, 333 tasks. It failed at `actions/configure-pages` purely because the repository had no Pages site yet, and the deploy job was skipped.

`enablement: true` makes the action create it, so the site does not depend on someone remembering to flip **Settings → Pages → Source** to GitHub Actions. The workflow already has the `pages: write` and `id-token: write` permissions it needs to do that.

I also noted in the workflow header that there is no `gh-pages` branch involved, since that is the thing people reasonably go looking for: `deploy-pages` uploads an artifact and serves it directly rather than committing built output to a branch.

After this merges the site should come up at **https://skydoves.github.io/nowinandroid-kmp/** on its own.
