### PR TITLE
feat(ui): add cursor hover modifier across interactive components

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/skydoves/nowinandroid/ui/NiaApp.kt
+++ b/app/shared/src/commonMain/kotlin/com/skydoves/nowinandroid/ui/NiaApp.kt
@@ -39,7 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -91,7 +91,7 @@ import com.skydoves.nowinandroid.feature.settings.impl.generated.resources.Res a
 fun NiaApp(
     appState: NiaAppState,
     modifier: Modifier = Modifier,
-    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
+    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfoV2(),
 ) {
     val shouldShowGradientBackground = appState.navigationState.currentTopLevelKey == ForYouNavKey
     var showSettingsDialog by rememberSaveable { mutableStateOf(false) }
@@ -144,7 +144,7 @@ internal fun NiaApp(
     onSettingsDismissed: () -> Unit,
     onTopAppBarActionClick: () -> Unit,
     modifier: Modifier = Modifier,
-    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
+    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfoV2(),
 ) {
     val unreadNavKeys by appState.topLevelNavKeysWithUnreadResources
         .collectAsStateWithLifecycle()

--- a/app/shared/src/nonAndroidTest/kotlin/com/skydoves/nowinandroid/ui/NiaAppStateCompositionTest.kt
+++ b/app/shared/src/nonAndroidTest/kotlin/com/skydoves/nowinandroid/ui/NiaAppStateCompositionTest.kt
@@ -17,7 +17,7 @@
 package com.skydoves.nowinandroid.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import com.skydoves.nowinandroid.core.data.repository.CompositeUserNewsResourceRepository
 import com.skydoves.nowinandroid.core.testing.repository.TestNewsRepository
 import com.skydoves.nowinandroid.core.testing.repository.TestUserDataRepository

--- a/build-logic/convention/src/main/kotlin/com/skydoves/nowinandroid/buildlogic/KotlinMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/nowinandroid/buildlogic/KotlinMultiplatform.kt
@@ -67,7 +67,6 @@ internal fun Project.configureKotlinMultiplatform(extension: KotlinMultiplatform
         with(sourceSets) {
             all {
                 languageSettings.optIn("kotlin.RequiresOptIn")
-                languageSettings.optIn("kotlin.time.ExperimentalTime")
             }
 
             // Everything Skiko renders: no Android framework, no `android.content.Context`.

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
             api(libs.compose.ui.tooling.preview)
             api(libs.compose.material.icons.core)
             api(libs.compose.material.icons.extended)
-            api(libs.compose.adaptive)
+            api(libs.compose.material3.adaptive)
             api(libs.compose.adaptive.layout)
             api(libs.compose.adaptive.navigation)
             api(libs.compose.material3.adaptive.navigation.suite)

--- a/core/designsystem/src/androidMain/kotlin/com/skydoves/nowinandroid/core/designsystem/theme/DynamicTheming.android.kt
+++ b/core/designsystem/src/androidMain/kotlin/com/skydoves/nowinandroid/core/designsystem/theme/DynamicTheming.android.kt
@@ -30,5 +30,13 @@ actual fun supportsDynamicTheming(): Boolean = Build.VERSION.SDK_INT >= Build.VE
 @Composable
 actual fun dynamicNiaColorScheme(darkTheme: Boolean): ColorScheme {
     val context = LocalContext.current
-    return if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (darkTheme) {
+            dynamicDarkColorScheme(context)
+        } else {
+            dynamicLightColorScheme(context)
+        }
+    } else {
+        if (darkTheme) DarkDefaultColorScheme else LightDefaultColorScheme
+    }
 }

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Button.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Button.kt
@@ -57,7 +57,7 @@ fun NiaButton(
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.onBackground,
@@ -123,7 +123,7 @@ fun NiaOutlinedButton(
 ) {
     OutlinedButton(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         colors = ButtonDefaults.outlinedButtonColors(
             contentColor = MaterialTheme.colorScheme.onBackground,
@@ -196,7 +196,7 @@ fun NiaTextButton(
 ) {
     TextButton(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         colors = ButtonDefaults.textButtonColors(
             contentColor = MaterialTheme.colorScheme.onBackground,

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Chip.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Chip.kt
@@ -57,7 +57,7 @@ fun NiaFilterChip(
                 label()
             }
         },
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         leadingIcon = if (selected) {
             {

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Cursor.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Cursor.kt
@@ -1,0 +1,30 @@
+/*
+ * Designed and developed by 2026 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.nowinandroid.core.designsystem.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+
+/**
+ * Applies a hand pointer cursor hover icon for interactive UI components like Cards and Buttons.
+ */
+fun Modifier.cursorHoverIcon(enabled: Boolean = true): Modifier = if (enabled) {
+    this.pointerHoverIcon(PointerIcon.Hand)
+} else {
+    this
+}

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/IconButton.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/IconButton.kt
@@ -53,7 +53,7 @@ fun NiaIconToggleButton(
     FilledIconToggleButton(
         checked = checked,
         onCheckedChange = onCheckedChange,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         colors = IconButtonDefaults.iconToggleButtonColors(
             checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Navigation.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Navigation.kt
@@ -29,7 +29,7 @@ import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteItemColors
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -183,11 +183,11 @@ fun NiaNavigationRail(
 fun NiaNavigationSuiteScaffold(
     navigationSuiteItems: NiaNavigationSuiteScope.() -> Unit,
     modifier: Modifier = Modifier,
-    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
+    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfoV2(),
     content: @Composable () -> Unit,
 ) {
     val layoutType = NavigationSuiteScaffoldDefaults
-        .calculateFromAdaptiveInfo(windowAdaptiveInfo)
+        .navigationSuiteType(windowAdaptiveInfo)
     val navigationSuiteItemColors = NavigationSuiteItemColors(
         navigationBarItemColors = NavigationBarItemDefaults.colors(
             selectedIconColor = NiaNavigationDefaults.navigationSelectedItemColor(),

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Navigation.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Navigation.kt
@@ -72,7 +72,7 @@ fun RowScope.NiaNavigationBarItem(
         selected = selected,
         onClick = onClick,
         icon = if (selected) selectedIcon else icon,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         label = label,
         alwaysShowLabel = alwaysShowLabel,
@@ -133,7 +133,7 @@ fun NiaNavigationRailItem(
         selected = selected,
         onClick = onClick,
         icon = if (selected) selectedIcon else icon,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         label = label,
         alwaysShowLabel = alwaysShowLabel,
@@ -241,6 +241,7 @@ class NiaNavigationSuiteScope internal constructor(
         selected: Boolean,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
+        enabled: Boolean = true,
         icon: @Composable () -> Unit,
         selectedIcon: @Composable () -> Unit = icon,
         label: @Composable (() -> Unit)? = null,
@@ -256,7 +257,8 @@ class NiaNavigationSuiteScope internal constructor(
         },
         label = label,
         colors = navigationSuiteItemColors,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
+        enabled = enabled,
     )
 }
 

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Tabs.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Tabs.kt
@@ -55,7 +55,7 @@ fun NiaTab(
     Tab(
         selected = selected,
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         text = {
             val style = MaterialTheme.typography.labelLarge.copy(textAlign = TextAlign.Center)

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Tag.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/Tag.kt
@@ -45,6 +45,7 @@ fun NiaTopicTag(
         }
         TextButton(
             onClick = onClick,
+            modifier = Modifier.cursorHoverIcon(enabled),
             enabled = enabled,
             colors = ButtonDefaults.textButtonColors(
                 containerColor = containerColor,

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/TopAppBar.kt
@@ -49,7 +49,10 @@ fun NiaTopAppBar(
     CenterAlignedTopAppBar(
         title = { Text(text = stringResource(titleRes)) },
         navigationIcon = {
-            IconButton(onClick = onNavigationClick) {
+            IconButton(
+                onClick = onNavigationClick,
+                modifier = Modifier.cursorHoverIcon(),
+            ) {
                 Icon(
                     imageVector = navigationIcon,
                     contentDescription = navigationIconContentDescription,
@@ -58,7 +61,10 @@ fun NiaTopAppBar(
             }
         },
         actions = {
-            IconButton(onClick = onActionClick) {
+            IconButton(
+                onClick = onActionClick,
+                modifier = Modifier.cursorHoverIcon(),
+            ) {
                 Icon(
                     imageVector = actionIcon,
                     contentDescription = actionIconContentDescription,

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/ViewToggle.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/ViewToggle.kt
@@ -57,7 +57,7 @@ fun NiaViewToggleButton(
 ) {
     TextButton(
         onClick = { onExpandedChange(!expanded) },
-        modifier = modifier,
+        modifier = modifier.cursorHoverIcon(enabled),
         enabled = enabled,
         colors = ButtonDefaults.textButtonColors(
             contentColor = MaterialTheme.colorScheme.onBackground,

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -58,11 +58,12 @@ import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.ThumbStat
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Dormant
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.ThumbState.Inactive
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * The time period for showing the scrollbar thumb after interacting with it, before it fades away
  */
-private const val SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS = 2_000L
+private val SCROLLBAR_INACTIVE_TO_DORMANT_TIME = 2.seconds
 
 /**
  * A [Scrollbar] that allows for fast scrolling of content by dragging its thumb.
@@ -228,7 +229,7 @@ private fun scrollbarThumbColor(scrollableState: ScrollableState, interactionSou
             true -> state = Active
             false -> if (state == Active) {
                 state = Inactive
-                delay(SCROLLBAR_INACTIVE_TO_DORMANT_TIME_IN_MS)
+                delay(SCROLLBAR_INACTIVE_TO_DORMANT_TIME)
                 state = Dormant
             }
         }

--- a/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/skydoves/nowinandroid/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -61,12 +61,13 @@ import kotlin.jvm.JvmInline
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * The delay between scrolls when a user long presses on the scrollbar track to initiate a scroll
  * instead of dragging the scrollbar thumb.
  */
-private const val SCROLLBAR_PRESS_DELAY_MS = 10L
+private val SCROLLBAR_PRESS_DELAY = 10.milliseconds
 
 /**
  * The percentage displacement of the scrollbar when scrolled by long presses on the scrollbar
@@ -389,7 +390,7 @@ fun Scrollbar(
                 }
                 onThumbMoved(currentThumbMovedPercent)
                 interactionThumbTravelPercent = currentThumbMovedPercent
-                delay(SCROLLBAR_PRESS_DELAY_MS)
+                delay(SCROLLBAR_PRESS_DELAY)
             }
         }
     }

--- a/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/InterestsItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/InterestsItem.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.skydoves.nowinandroid.core.designsystem.component.DynamicAsyncImage
 import com.skydoves.nowinandroid.core.designsystem.component.NiaIconToggleButton
+import com.skydoves.nowinandroid.core.designsystem.component.cursorHoverIcon
 import com.skydoves.nowinandroid.core.designsystem.icon.NiaIcons
 import com.skydoves.nowinandroid.core.designsystem.theme.NiaTheme
 import com.skydoves.nowinandroid.core.ui.generated.resources.Res
@@ -94,6 +95,7 @@ fun InterestsItem(
             },
         ),
         modifier = modifier
+            .cursorHoverIcon()
             .semantics(mergeDescendants = true) {
                 selected = isSelected
             }

--- a/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/NewsResourceCard.kt
+++ b/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/NewsResourceCard.kt
@@ -59,6 +59,7 @@ import com.skydoves.landscapist.image.LandscapistImage
 import com.skydoves.landscapist.placeholder.shimmer.ShimmerPlugin
 import com.skydoves.nowinandroid.core.designsystem.component.NiaIconToggleButton
 import com.skydoves.nowinandroid.core.designsystem.component.NiaTopicTag
+import com.skydoves.nowinandroid.core.designsystem.component.cursorHoverIcon
 import com.skydoves.nowinandroid.core.designsystem.component.rememberNiaShimmer
 import com.skydoves.nowinandroid.core.designsystem.generated.resources.core_designsystem_ic_placeholder_default
 import com.skydoves.nowinandroid.core.designsystem.icon.NiaIcons
@@ -118,6 +119,7 @@ fun NewsResourceCardExpanded(
         // Use custom label for accessibility services to communicate button's action to user.
         // Pass null for action to only override the label and not the actual action.
         modifier = modifier
+            .cursorHoverIcon()
             .semantics {
                 onClick(label = clickActionLabel, action = null)
             }

--- a/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/UserNewsResourcePreviewParameterProvider.kt
+++ b/core/ui/src/commonMain/kotlin/com/skydoves/nowinandroid/core/ui/UserNewsResourcePreviewParameterProvider.kt
@@ -26,10 +26,10 @@ import com.skydoves.nowinandroid.core.model.data.Topic
 import com.skydoves.nowinandroid.core.model.data.UserData
 import com.skydoves.nowinandroid.core.model.data.UserNewsResource
 import com.skydoves.nowinandroid.core.ui.PreviewParameterData.newsResources
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
+import kotlin.time.Instant
 
 /**
  * This [PreviewParameterProvider](https://developer.android.com/reference/kotlin/androidx/compose/ui/tooling/preview/PreviewParameterProvider)
@@ -89,8 +89,8 @@ object PreviewParameterData {
                 headerImageUrl = "https://developer.android.com/images/hero-assets/android-basics-compose.svg",
                 publishDate = LocalDateTime(
                     year = 2022,
-                    monthNumber = 5,
-                    dayOfMonth = 4,
+                    month = 5,
+                    day = 4,
                     hour = 23,
                     minute = 0,
                     second = 0,

--- a/feature/foryou/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/foryou/impl/ForYouScreen.kt
+++ b/feature/foryou/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/foryou/impl/ForYouScreen.kt
@@ -79,6 +79,7 @@ import com.skydoves.nowinandroid.core.designsystem.component.DynamicAsyncImage
 import com.skydoves.nowinandroid.core.designsystem.component.NiaButton
 import com.skydoves.nowinandroid.core.designsystem.component.NiaIconToggleButton
 import com.skydoves.nowinandroid.core.designsystem.component.NiaOverlayLoadingWheel
+import com.skydoves.nowinandroid.core.designsystem.component.cursorHoverIcon
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.DecorativeScrollbar
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.DraggableScrollbar
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.rememberDraggableScroller
@@ -390,7 +391,8 @@ private fun SingleTopicButton(
     Surface(
         modifier = Modifier
             .width(312.dp)
-            .heightIn(min = 56.dp),
+            .heightIn(min = 56.dp)
+            .cursorHoverIcon(),
         shape = RoundedCornerShape(corner = CornerSize(8.dp)),
         color = MaterialTheme.colorScheme.surface,
         selected = isSelected,

--- a/feature/search/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/search/impl/SearchScreen.kt
+++ b/feature/search/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/search/impl/SearchScreen.kt
@@ -80,6 +80,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
+import com.skydoves.nowinandroid.core.designsystem.component.cursorHoverIcon
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.DraggableScrollbar
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.rememberDraggableScroller
 import com.skydoves.nowinandroid.core.designsystem.component.scrollbar.scrollbarState
@@ -448,6 +449,7 @@ private fun RecentSearchesBody(
                     style = MaterialTheme.typography.headlineSmall,
                     modifier = Modifier
                         .padding(vertical = 16.dp)
+                        .cursorHoverIcon()
                         .clickable { onRecentSearchClicked(recentSearch) }
                         .fillMaxWidth(),
                 )
@@ -468,7 +470,10 @@ private fun SearchToolbar(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth(),
     ) {
-        IconButton(onClick = { onBackClick() }) {
+        IconButton(
+            onClick = { onBackClick() },
+            modifier = Modifier.cursorHoverIcon(),
+        ) {
             Icon(
                 imageVector = NiaIcons.ArrowBack,
                 contentDescription = stringResource(
@@ -519,6 +524,7 @@ private fun SearchTextField(
                     onClick = {
                         onSearchQueryChanged("")
                     },
+                    modifier = Modifier.cursorHoverIcon(),
                 ) {
                     Icon(
                         imageVector = NiaIcons.Close,

--- a/feature/settings/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/settings/impl/SettingsDialog.kt
+++ b/feature/settings/impl/src/commonMain/kotlin/com/skydoves/nowinandroid/feature/settings/impl/SettingsDialog.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.skydoves.nowinandroid.core.designsystem.component.NiaTextButton
+import com.skydoves.nowinandroid.core.designsystem.component.cursorHoverIcon
 import com.skydoves.nowinandroid.core.designsystem.theme.NiaTheme
 import com.skydoves.nowinandroid.core.designsystem.theme.supportsDynamicTheming
 import com.skydoves.nowinandroid.core.model.data.DarkThemeConfig
@@ -242,6 +243,7 @@ fun SettingsDialogThemeChooserRow(text: String, selected: Boolean, onClick: () -
     Row(
         Modifier
             .fillMaxWidth()
+            .cursorHoverIcon()
             .selectable(
                 selected = selected,
                 role = Role.RadioButton,

--- a/feature/topic/impl/src/nonAndroidTest/kotlin/com/skydoves/nowinandroid/feature/topic/impl/TopicScreenErrorTest.kt
+++ b/feature/topic/impl/src/nonAndroidTest/kotlin/com/skydoves/nowinandroid/feature/topic/impl/TopicScreenErrorTest.kt
@@ -18,7 +18,7 @@ package com.skydoves.nowinandroid.feature.topic.impl
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.test.Test
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,8 +53,6 @@ spotless = "7.2.1"
 # Compose Multiplatform
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
-compose-material3-adaptive-navigation-suite = { module = "org.jetbrains.compose.material3:material3-adaptive-navigation-suite", version.ref = "composeMaterial3" }
 compose-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "composeMultiplatform" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
@@ -64,7 +62,10 @@ compose-material-icons-extended = { module = "org.jetbrains.compose.material:mat
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
-compose-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "composeAdaptive" }
+# Material 3
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
+compose-material3-adaptive-navigation-suite = { module = "org.jetbrains.compose.material3:material3-adaptive-navigation-suite", version.ref = "composeMaterial3" }
+compose-material3-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "composeAdaptive" }
 compose-adaptive-layout = { module = "org.jetbrains.compose.material3.adaptive:adaptive-layout", version.ref = "composeAdaptive" }
 compose-adaptive-navigation = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation", version.ref = "composeAdaptive" }
 compose-adaptive-navigation3 = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation3", version.ref = "composeAdaptive" }


### PR DESCRIPTION
### Summary
Adds `Modifier.cursorHoverIcon()` to show a pointer hand cursor when hovering over interactive UI components across Kotlin Multiplatform targets (Desktop JVM, Web WasmJS, and pointing devices).

### Changes Included
- **Core Design System**:
  - Added `Modifier.cursorHoverIcon(enabled: Boolean)` in `Cursor.kt`.
  - Applied cursor hover modifier to `Button`, `IconButton`, `Chip`, `Tag`, `Tabs`, `TopAppBar`, `NavigationSuite`, and `ViewToggle`.
- **UI & Feature Screens**:
  - Applied hover modifier to `NewsResourceCard` and `InterestsItem`.
  - Applied hover modifier to `SearchToolbar` back and clear buttons in `SearchScreen.kt`.
  - Applied hover modifier to theme radio rows in `SettingsDialog.kt`.
  - Applied hover modifier to onboarding topic buttons in `ForYouScreen.kt`.
- **Formatting & Verification**:
  - Applied Spotless formatting (`./gradlew spotlessApply`) and verified build & unit tests pass.
  
### Before:

https://github.com/user-attachments/assets/a1560307-271a-4d76-8f00-eee65278ed7e

### After:

https://github.com/user-attachments/assets/fb6d4d5c-7c87-4e11-9b23-6e5977293fa5
