### PR TITLE
Update Landscapist to 2.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ kotlinxSerialization = "1.11.0"
 kotlinxImmutable = "0.5.2"
 kotlinxDatetime = "0.8.0"
 
-landscapist = "2.12.1"
+landscapist = "2.13.0"
 composeRuntimeAnnotation = "1.12.0"
 composeNavGraph = "0.2.1"
 hotswan = "2.0.0-beta04"


### PR DESCRIPTION
Bumps Landscapist from 2.12.1 to 2.13.0. One line in `gradle/libs.versions.toml`.

## What is in 2.13.0

A performance release: the Compose layer is rebuilt on `Modifier.Node`, the core decodes at the size the layout asked for, and desktop decode goes through Skia instead of reading the whole raster and shrinking it afterwards. The public API is additive, so nothing here had to change. `LandscapistImage` with `ShimmerPlugin`, the `failure` slot, and `SvgImageDecoder` in the builder all carry over unchanged, and the build produces no Landscapist deprecation warnings.

## Why this was verified by running the app

The desktop decode path is exactly what broke in 2.12.0, where a `BufferedImage` never reached a Skia painter and every raster image rendered blank. Compilation succeeded and every test passed while the app showed nothing, so this bump was checked by launching the app on each platform and looking at the result.

| Platform | Raster images | SVG topic icons |
|---|---|---|
| Android | feed header images render | render |
| iOS | feed header images render | all render |
| Desktop | all three feed cards render | render |
| Web (wasm) | feed renders | all twelve render |

No crashes, and nothing in logcat or the browser console beyond the pre-existing CORS failures from `blogger.googleusercontent.com` that the README already documents.

## Test plan

- [x] `spotlessCheck`
- [x] `desktopTest` (158)
- [x] `iosSimulatorArm64Test` (139)
- [x] `testAndroidHostTest` (117)
- [x] `:app:androidApp:assembleDebug`
- [x] `:app:webApp:wasmJsBrowserDistribution`
- [x] `:app:shared:linkDebugFrameworkIosSimulatorArm64`
- [x] `navCheck`
- [x] App launched and exercised on Android, iOS, desktop and web

`NiaImagePipelineTest` covers the decoder chain directly, including that an SVG rasterises at the size the layout requested rather than its own, and it passes on both desktop and iOS.
